### PR TITLE
Correct np data type for onnx

### DIFF
--- a/ruphon/ruphon.py
+++ b/ruphon/ruphon.py
@@ -95,7 +95,7 @@ class RUPhon:
 
     def _predict_single(self, word: str) -> List[str]:
         inputs = self.tokenizer([word.lower()], padding=True, return_tensors="np")
-        ort_inputs = {name: inputs[name] for name in self.input_names}
+        ort_inputs = {name: inputs[name].astype(np.int64) for name in self.input_names}
         ort_outputs = self.ort_session.run(self.output_names, ort_inputs)
         
         logits = ort_outputs[0]


### PR DESCRIPTION
Upon encountering an error with the data types, I've corrected it by casting the inputs to in64 instead of the default int32, this was tested on CPU