### PR TITLE
Fix transformers compatibility and token_type_ids handling

### DIFF
--- a/ruphon/char_tokenizer.py
+++ b/ruphon/char_tokenizer.py
@@ -4,13 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
 
 from transformers.tokenization_utils import AddedToken, PreTrainedTokenizer
-from transformers.utils import (
-    cached_file,
-    copy_func,
-    download_url,
-    extract_commit_hash,
-    is_remote_url,
-)
+from transformers.utils import cached_file, extract_commit_hash
 
 
 class CharacterTokenizer(PreTrainedTokenizer):

--- a/ruphon/ruphon.py
+++ b/ruphon/ruphon.py
@@ -13,6 +13,7 @@ from .char_tokenizer import CharacterTokenizer
 
 
 class TextPreprocessor:
+    @staticmethod
     def split_by_words(string):
         string = string.replace(" - ",' ^ ')
         match = list(re.finditer(r"\w*(?:\+\w+)*|[^\w\s]+", string.lower()))
@@ -28,6 +29,7 @@ class TextPreprocessor:
         remaining_text_res.append("".join(remaining_text[words_mask[-1]+1:]))
         return valid_words, remaining_text_res
 
+    @staticmethod
     def split_by_sentences(string):
         sentences = list(sentenize(string))
         if len(sentences) == 0:
@@ -36,6 +38,7 @@ class TextPreprocessor:
         result[-1] = result[-1] + string[sentences[-1].stop:]
         return result
         
+    @staticmethod
     def delete_spaces_before_punc(text):
         punc = "!\"#$%&()*,./:;<=>?@[\\]_`{|}-"
         for char in punc:
@@ -95,7 +98,14 @@ class RUPhon:
 
     def _predict_single(self, word: str) -> List[str]:
         inputs = self.tokenizer([word.lower()], padding=True, return_tensors="np")
-        ort_inputs = {name: inputs[name].astype(np.int64) for name in self.input_names}
+        ort_inputs = {}
+        for name in self.input_names:
+            if name in inputs:
+                ort_inputs[name] = inputs[name].astype(np.int64)
+            elif name == "token_type_ids":
+                ort_inputs[name] = np.zeros_like(inputs["input_ids"])
+            else:
+                raise KeyError(f"Expected input '{name}' not found in tokenizer output: {list(inputs.keys())}")
         ort_outputs = self.ort_session.run(self.output_names, ort_inputs)
         
         logits = ort_outputs[0]


### PR DESCRIPTION
- Remove unused imports (download_url, is_remote_url, copy_func) that were removed in newer transformers versions
- Add fallback for missing token_type_ids in tokenizer output (modern transformers no longer returns it by default)
- Add @staticmethod decorators to TextPreprocessor methods

Fixes import error with transformers >= 4.47.0